### PR TITLE
Rename UniFFI `delete` param to `delete_count` (C++ keyword collision)

### DIFF
--- a/AutomergeUniffi/automerge.swift
+++ b/AutomergeUniffi/automerge.swift
@@ -654,9 +654,9 @@ public protocol DocProtocol : AnyObject {
     
     func setActor(actor: ActorId) 
     
-    func splice(obj: ObjId, start: UInt64, delete: Int64, values: [ScalarValue]) throws 
+    func splice(obj: ObjId, start: UInt64, deleteCount: Int64, values: [ScalarValue]) throws 
     
-    func spliceText(obj: ObjId, start: UInt64, delete: Int64, chars: String) throws 
+    func spliceText(obj: ObjId, start: UInt64, deleteCount: Int64, chars: String) throws 
     
     func splitBlock(obj: ObjId, index: UInt32) throws  -> ObjId
     
@@ -1219,21 +1219,21 @@ open func setActor(actor: ActorId) {try! rustCall() {
 }
 }
     
-open func splice(obj: ObjId, start: UInt64, delete: Int64, values: [ScalarValue])throws  {try rustCallWithError(FfiConverterTypeDocError.lift) {
+open func splice(obj: ObjId, start: UInt64, deleteCount: Int64, values: [ScalarValue])throws  {try rustCallWithError(FfiConverterTypeDocError.lift) {
     uniffi_uniffi_automerge_fn_method_doc_splice(self.uniffiClonePointer(),
         FfiConverterTypeObjId.lower(obj),
         FfiConverterUInt64.lower(start),
-        FfiConverterInt64.lower(delete),
+        FfiConverterInt64.lower(deleteCount),
         FfiConverterSequenceTypeScalarValue.lower(values),$0
     )
 }
 }
     
-open func spliceText(obj: ObjId, start: UInt64, delete: Int64, chars: String)throws  {try rustCallWithError(FfiConverterTypeDocError.lift) {
+open func spliceText(obj: ObjId, start: UInt64, deleteCount: Int64, chars: String)throws  {try rustCallWithError(FfiConverterTypeDocError.lift) {
     uniffi_uniffi_automerge_fn_method_doc_splice_text(self.uniffiClonePointer(),
         FfiConverterTypeObjId.lower(obj),
         FfiConverterUInt64.lower(start),
-        FfiConverterInt64.lower(delete),
+        FfiConverterInt64.lower(deleteCount),
         FfiConverterString.lower(chars),$0
     )
 }
@@ -3580,10 +3580,10 @@ private var initializationResult: InitializationResult = {
     if (uniffi_uniffi_automerge_checksum_method_doc_set_actor() != 64337) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_splice() != 29894) {
+    if (uniffi_uniffi_automerge_checksum_method_doc_splice() != 16143) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_uniffi_automerge_checksum_method_doc_splice_text() != 20602) {
+    if (uniffi_uniffi_automerge_checksum_method_doc_splice_text() != 31095) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_uniffi_automerge_checksum_method_doc_split_block() != 10956) {

--- a/Sources/Automerge/Document.swift
+++ b/Sources/Automerge/Document.swift
@@ -718,7 +718,7 @@ public final class Document: @unchecked Sendable {
             defer { sendObjectDidChange() }
             try self.doc.wrapErrors {
                 try $0.splice(
-                    obj: obj.bytes, start: start, delete: delete, values: values.map { $0.toFfi() }
+                    obj: obj.bytes, start: start, deleteCount: delete, values: values.map { $0.toFfi() }
                 )
             }
         }
@@ -767,7 +767,7 @@ public final class Document: @unchecked Sendable {
             sendObjectWillChange()
             defer { sendObjectDidChange() }
             try self.doc.wrapErrors {
-                try $0.spliceText(obj: obj.bytes, start: start, delete: delete, chars: value ?? "")
+                try $0.spliceText(obj: obj.bytes, start: start, deleteCount: delete, chars: value ?? "")
             }
         }
     }

--- a/Sources/_CAutomergeUniffi/include/automergeFFI.h
+++ b/Sources/_CAutomergeUniffi/include/automergeFFI.h
@@ -554,12 +554,12 @@ void uniffi_uniffi_automerge_fn_method_doc_set_actor(void*_Nonnull ptr, RustBuff
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_UNIFFI_AUTOMERGE_FN_METHOD_DOC_SPLICE
 #define UNIFFI_FFIDEF_UNIFFI_UNIFFI_AUTOMERGE_FN_METHOD_DOC_SPLICE
-void uniffi_uniffi_automerge_fn_method_doc_splice(void*_Nonnull ptr, RustBuffer obj, uint64_t start, int64_t delete, RustBuffer values, RustCallStatus *_Nonnull out_status
+void uniffi_uniffi_automerge_fn_method_doc_splice(void*_Nonnull ptr, RustBuffer obj, uint64_t start, int64_t delete_count, RustBuffer values, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_UNIFFI_AUTOMERGE_FN_METHOD_DOC_SPLICE_TEXT
 #define UNIFFI_FFIDEF_UNIFFI_UNIFFI_AUTOMERGE_FN_METHOD_DOC_SPLICE_TEXT
-void uniffi_uniffi_automerge_fn_method_doc_splice_text(void*_Nonnull ptr, RustBuffer obj, uint64_t start, int64_t delete, RustBuffer chars, RustCallStatus *_Nonnull out_status
+void uniffi_uniffi_automerge_fn_method_doc_splice_text(void*_Nonnull ptr, RustBuffer obj, uint64_t start, int64_t delete_count, RustBuffer chars, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_UNIFFI_AUTOMERGE_FN_METHOD_DOC_SPLIT_BLOCK

--- a/rust/src/automerge.udl
+++ b/rust/src/automerge.udl
@@ -173,12 +173,12 @@ interface Doc {
     ObjId insert_object_in_list(ObjId obj, u64 index, ObjType obj_type);
 
     [Throws=DocError]
-    void splice_text(ObjId obj, u64 start, i64 delete, string chars);
+    void splice_text(ObjId obj, u64 start, i64 delete_count, string chars);
     [Throws=DocError]
     void update_text(ObjId obj, string chars);
 
     [Throws=DocError]
-    void splice(ObjId obj, u64 start, i64 delete, sequence<ScalarValue> values);
+    void splice(ObjId obj, u64 start, i64 delete_count, sequence<ScalarValue> values);
 
     [Throws=DocError]
     void mark(ObjId obj, u64 start, u64 end, ExpandMark expand, string name, ScalarValue value);

--- a/rust/src/doc.rs
+++ b/rust/src/doc.rs
@@ -432,13 +432,13 @@ impl Doc {
         &self,
         obj: ObjId,
         start: u64,
-        delete: i64,
+        delete_count: i64,
         value: String,
     ) -> Result<(), DocError> {
         let obj = am::ObjId::from(obj);
         let mut doc = self.0.write().unwrap();
         assert_text(&*doc, &obj)?;
-        doc.splice_text(&obj, start as usize, delete as isize, value.as_str())?;
+        doc.splice_text(&obj, start as usize, delete_count as isize, value.as_str())?;
         Ok(())
     }
 
@@ -454,7 +454,7 @@ impl Doc {
         &self,
         obj: ObjId,
         start: u64,
-        delete: i64,
+        delete_count: i64,
         values: Vec<ScalarValue>,
     ) -> Result<(), DocError> {
         let obj = am::ObjId::from(obj);
@@ -463,7 +463,7 @@ impl Doc {
         doc.splice(
             &obj,
             start as usize,
-            delete as isize,
+            delete_count as isize,
             values.into_iter().map(|i| i.into()),
         )?;
         Ok(())


### PR DESCRIPTION
The UDL `splice`/`splice_text` methods declared a parameter named `delete`, which UniFFI emits verbatim into the generated C FFI header (automergeFFI.h). `delete` is a C++ keyword, so any consumer that imports that header under C++ (e.g. Swift/C++ interop, `SWIFT_OBJC_INTEROP_MODE=objcxx`) fails to build the Clang module with "invalid parameter name: 'delete' is a keyword".